### PR TITLE
Galiojanti suvestinė redakcija (nuo 2019-07-01)

### DIFF
--- a/questions.yml
+++ b/questions.yml
@@ -2178,7 +2178,7 @@ a:
       choice:
         - /m.
         - /mm.
-        - /am.
+        - /p.
       answer: 0
       # Papildant radijo šaukinį naudojant radijo ryšio stotį laive, galima naudoti /m simbolį. Šis simbolis nurodo, kad laivas naudoja mobilųjį radijo ryšį. Kitaip tariant, tai reiškia, kad laivas yra judantis ir gali keisti savo padėtį.
 

--- a/questions.yml
+++ b/questions.yml
@@ -2020,7 +2020,7 @@ a:
 
     - text: Koks maksimalus Lietuvos Respublikos ryšių reguliavimo tarnybos išduoto leidimo užsiimti radijo mėgėjų veikla terminas?
       choice:
-        - 5 metai.
+        - 10 metų.
         - 3 metai.
         - 1 metai.
       answer: 0

--- a/src/assets/questions.json
+++ b/src/assets/questions.json
@@ -2557,7 +2557,7 @@
       {
         "text": "Koks maksimalus Lietuvos Respublikos ryšių reguliavimo tarnybos išduoto leidimo užsiimti radijo mėgėjų veikla terminas?",
         "choice": [
-          "5 metai.",
+          "10 metų.",
           "3 metai.",
           "1 metai."
         ],


### PR DESCRIPTION
Dėl Teisės užsiimti radijo mėgėjų veikla suteikimo tvarkos ir užsiėmimo šia veikla sąlygų aprašo patvirtinimo.

12 punktas:
Leidimas užsiimti radijo mėgėjų veikla išduodamas 10 metų terminui, išskyrus Aprašo 19 punkte nurodytą atvejį.